### PR TITLE
Grafana f2b_errors

### DIFF
--- a/_examples/grafana/dashboard.json
+++ b/_examples/grafana/dashboard.json
@@ -801,7 +801,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "f2b_errors{instance=~\"$instance\"}",
+          "expr": "increase(f2b_errors{instance=~\"$instance\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{type}} ({{instance}})",
           "range": true,


### PR DESCRIPTION
I'm not a Grafana expert but I think using `increase()`  function makes sense here (otherwise it adds up new errors to the counter, making a "always growing" graph)